### PR TITLE
Add store credit to list of payment_methods.

### DIFF
--- a/lib/spree_store_credits/engine.rb
+++ b/lib/spree_store_credits/engine.rb
@@ -16,5 +16,9 @@ module SpreeStoreCredits
     end
 
     config.to_prepare &method(:activate).to_proc
+
+    initializer "spree.gateway.payment_methods", :after => "spree.register.payment_methods" do |app|
+      app.config.spree.payment_methods << Spree::PaymentMethod::StoreCredit
+    end
   end
 end


### PR DESCRIPTION
This will currently cause issues if you attempt to save the store credit
payment method in the Spree admin interface because the gateway is not
in the list of available payment methods.

It will default the store credit payment method to the first payment
method in the list, save with that, and now allow you to change it back,
thereby breaking everything!
