### PR TITLE
[2.2] Set store credit amount input step to any.

### DIFF
--- a/app/views/spree/admin/store_credits/_form.html.erb
+++ b/app/views/spree/admin/store_credits/_form.html.erb
@@ -2,7 +2,7 @@
   <div class="alpha twelve columns">
     <%= f.field_container :amount do %>
       <%= f.label :amount, Spree.t(:amount) %> <span class="required">*</span><br />
-      <%= f.number_field :amount, min: 0.00 %>
+      <%= f.number_field :amount, min: 0.00, step: :any %>
       <%= f.error_message_on :amount %>
     <% end %>
   </div>


### PR DESCRIPTION
This will allow decimal values in the store step, such as, $0.02.
Previously this would lead to an error where an HTML5 compatible browser
would ask you to input either 0 or 1.
