### PR TITLE
Store originator on store credit events

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,10 @@ gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: '2-2-stable'
 
 gemspec
 
+group :test do
+  gem 'with_model'
+end
+
 group :test, :development do
   gem 'pry-byebug'
 end

--- a/app/controllers/spree/admin/store_credits_controller.rb
+++ b/app/controllers/spree/admin/store_credits_controller.rb
@@ -14,8 +14,12 @@ module Spree
       end
 
       def create
-        @store_credit = @user.store_credits.build(permitted_store_credit_params)
-        @store_credit.created_by = try_spree_current_user
+        @store_credit = @user.store_credits.build(
+          permitted_store_credit_params.merge({
+            created_by: try_spree_current_user,
+            action_originator: try_spree_current_user,
+          })
+        )
 
         if @store_credit.save
           flash[:success] = flash_message_for(@store_credit, :successfully_created)

--- a/app/models/spree/payment_decorator.rb
+++ b/app/models/spree/payment_decorator.rb
@@ -28,10 +28,12 @@ module SpreeStoreCredits::PaymentDecorator
       # if the source is a store credit.
       return unless store_credit? && source.is_a?(Spree::StoreCredit)
 
-      source.action = Spree::StoreCredit::ELIGIBLE_ACTION
-      source.authorization_code = response_code
-      source.action_amount = amount
-      source.save! # creates the store credit event
+      # creates the store credit event
+      source.update_attributes!({
+        action: Spree::StoreCredit::ELIGIBLE_ACTION,
+        action_amount: amount,
+        action_authorization_code: response_code,
+      })
     end
 
     def invalidate_old_payments

--- a/app/models/spree/store_credit_event.rb
+++ b/app/models/spree/store_credit_event.rb
@@ -3,6 +3,7 @@ module Spree
     acts_as_paranoid
 
     belongs_to :store_credit
+    belongs_to :originator, polymorphic: true
 
     scope :exposed_events, -> { where.not(action: [Spree::StoreCredit::ELIGIBLE_ACTION, Spree::StoreCredit::AUTHORIZE_ACTION]) }
     scope :reverse_chronological, -> { order(created_at: :desc) }

--- a/app/models/spree/virtual_gift_card.rb
+++ b/app/models/spree/virtual_gift_card.rb
@@ -21,7 +21,15 @@ class Spree::VirtualGiftCard < ActiveRecord::Base
 
   def redeem(redeemer)
     return false if redeemed?
-    self.build_store_credit(amount: self.amount, currency: self.currency, memo: self.memo, user: redeemer, created_by: redeemer, category: self.store_credit_category).save
+    self.build_store_credit({
+      amount: self.amount,
+      currency: self.currency,
+      memo: self.memo,
+      user: redeemer,
+      created_by: redeemer,
+      action_originator: self,
+      category: self.store_credit_category,
+    }).save
     self.update_attributes( redeemed_at: Time.now, redeemer: redeemer )
   end
 

--- a/db/migrate/20140812120911_add_originator_to_store_credits.rb
+++ b/db/migrate/20140812120911_add_originator_to_store_credits.rb
@@ -1,0 +1,6 @@
+class AddOriginatorToStoreCredits < ActiveRecord::Migration
+  def change
+    add_column :spree_store_credit_events, :originator_id, :integer
+    add_column :spree_store_credit_events, :originator_type, :string
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -93,6 +93,8 @@ RSpec.configure do |config|
   config.include Devise::TestHelpers, type: :controller
   config.extend AuthenticationSupport
 
+  config.extend WithModel
+
   config.before do
     Spree::Api::Config[:requires_authentication] = true
     Spree::StoreCredits::Configuration.set_configs(non_expiring_credit_types: ['Non-expiring'])


### PR DESCRIPTION
This allows admins, gift cards, reimbursements, refunds, etc to be recorded as the "originator" of a store credit event.
- Add originator_id and originator_type fields on spree_store_credit_events table
- Allow sending an "originator" property via payment method authorize/capture/purchase/void/credit calls
- Add an action_originator attr_accessor on StoreCredit that propagates to the StoreCreditEvent on save
- Send an originator to StoreCredit when redeeming a gift card
- Send an originator to StoreCredit when granting a store credit via the Admin UI

Also:
- Rename StoreCredit#authorization_code -> #action_authorization_code to match the other "action" properties
- Refactor some method calls a bit
- Refactor some specs a bit
