### PR TITLE
[2-2-stable] Compare state directly in specs.

### DIFF
--- a/spec/models/spree/order_decorator_spec.rb
+++ b/spec/models/spree/order_decorator_spec.rb
@@ -123,7 +123,7 @@ describe "Order" do
         before { subject }
 
         it "should invalidate the credit card payment" do
-          cc_payment.reload.should be_invalid
+          cc_payment.reload.state.should == 'invalid'
         end
       end
 


### PR DESCRIPTION
Previously this test used the invalid? method definition from state
machine which conflicted with a method from ActiveModel. Instead of
dealing with that issue, we will compare the state directly to what it
should be rather than relying upon the magic methods defined by
state_machine.

Fixes #5
