### PR TITLE
Lock store credit before modifying.

### DIFF
--- a/app/models/spree/payment_method/store_credit.rb
+++ b/app/models/spree/payment_method/store_credit.rb
@@ -80,13 +80,15 @@ module Spree
     private
 
     def handle_action_call(store_credit, action, action_name, auth_code=nil)
-      if response = action.call(store_credit)
-        # note that we only need to return the auth code on an 'auth', but it's innocuous to always return
-        ActiveMerchant::Billing::Response.new(true,
-                                              Spree.t('store_credit_payment_method.successful_action', action: action_name),
-                                              {}, { authorization: auth_code || response })
-      else
-        ActiveMerchant::Billing::Response.new(false, store_credit.errors.full_messages.join, {}, {})
+      store_credit.with_lock do
+        if response = action.call(store_credit)
+          # note that we only need to return the auth code on an 'auth', but it's innocuous to always return
+          ActiveMerchant::Billing::Response.new(true,
+                                                Spree.t('store_credit_payment_method.successful_action', action: action_name),
+                                                {}, { authorization: auth_code || response })
+        else
+          ActiveMerchant::Billing::Response.new(false, store_credit.errors.full_messages.join, {}, {})
+        end
       end
     end
 


### PR DESCRIPTION
This prevents a potential race condition where store credit can be
consumed by multiple checkouts happening simultaneously.

As with most race conditions, it's difficult to replicate in a test
environment, but this will now lock the store credit prior to
modification, so that modifications happen within a transaction with the
correct up to date values.
