### PR TITLE
Add store credit display to checkout flow

### DIFF
--- a/app/assets/stylesheets/spree/frontend/checkout_store_credits.css
+++ b/app/assets/stylesheets/spree/frontend/checkout_store_credits.css
@@ -1,0 +1,11 @@
+.bottom-accent-separator {
+  border-bottom: 2px solid black;
+}
+
+.top-accent-separator {
+  border-top: 2px solid black;
+}
+
+.top-accent-separator.light {
+  border-top: 1px solid #d9d9db;
+}

--- a/app/assets/stylesheets/spree/frontend/spree_store_credits.css
+++ b/app/assets/stylesheets/spree/frontend/spree_store_credits.css
@@ -1,4 +1,6 @@
 /*
 Placeholder manifest file.
 the installer will append this file to the app vendored assets here: 'vendor/assets/stylesheets/spree/frontend/all.css'
+
+ *= require_tree .
 */

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -58,6 +58,10 @@ module SpreeStoreCredits::OrderDecorator
       total - total_applicable_store_credit
     end
 
+    def using_store_credit?
+      total_applicable_store_credit > 0
+    end
+
     def total_applicable_store_credit
       if confirm? || complete?
         payments.store_credits.valid.sum(:amount)

--- a/app/overrides/order_details_store_credit.rb
+++ b/app/overrides/order_details_store_credit.rb
@@ -1,0 +1,13 @@
+Deface::Override.new(
+  virtual_path: 'spree/shared/_order_details',
+  name: 'order_details_store_credit',
+  insert_after: '[data-hook="order_details_adjustments"]',
+  partial: 'spree/shared/order_details_store_credit'
+)
+
+Deface::Override.new(
+  virtual_path: 'spree/shared/_order_details',
+  name: 'order_details_store_credit_change_total',
+  replace_contents: '[data-hook="order_details_total"] .total',
+  partial: 'spree/shared/order_details_total_charge'
+)

--- a/app/overrides/user_checkout_payment_store_credit.rb
+++ b/app/overrides/user_checkout_payment_store_credit.rb
@@ -1,0 +1,7 @@
+Deface::Override.new(
+  virtual_path: 'spree/checkout/_payment',
+  name: 'insert_store_credit_instructions',
+  insert_before: 'erb:contains("@payment_sources.present?")',
+  partial: 'spree/checkout/payment_through_store_credit'
+)
+

--- a/app/overrides/user_sidebar_store_credits.rb
+++ b/app/overrides/user_sidebar_store_credits.rb
@@ -1,0 +1,13 @@
+Deface::Override.new(
+  virtual_path: 'spree/checkout/_summary',
+  name: 'add_store_credit',
+  insert_before: '[data-hook="order_total"]',
+  partial: 'spree/checkout/store_credits_sidebar'
+)
+
+Deface::Override.new(
+  virtual_path: 'spree/checkout/_summary',
+  name: 'replace_order_total',
+  replace_contents: '[data-hook="order_total"]',
+  partial: 'spree/checkout/balance_due_sidebar',
+)

--- a/app/views/spree/checkout/_balance_due_sidebar.html.erb
+++ b/app/views/spree/checkout/_balance_due_sidebar.html.erb
@@ -1,0 +1,2 @@
+<td><strong>Balance Due:</strong></td>
+<td><strong><span id='summary-order-total'><%= order.display_order_total_after_store_credit.to_html %></span></strong></td>

--- a/app/views/spree/checkout/_payment_through_store_credit.html.erb
+++ b/app/views/spree/checkout/_payment_through_store_credit.html.erb
@@ -1,0 +1,9 @@
+<% if @order.total_applicable_store_credit > 0 %>
+  <h6>Store credit will be applied for this order!</h6>
+  <p><%= Spree::Money.new(@order.total_applicable_store_credit, { currency: @order.currency }).to_html %> in store credit will be applied to this order (<%= @order.display_store_credit_remaining_after_capture.to_html %> remaining)</p>
+  <% if @order.covered_by_store_credit? %>
+    <p>Please enter payment information below. Your credit card will <strong>not</strong> be charged.</p>
+  <% else %>
+    <p>Please enter additional payment method below for the remaining total on your order.</p>
+  <% end %>
+<% end %>

--- a/app/views/spree/checkout/_payment_through_store_credit.html.erb
+++ b/app/views/spree/checkout/_payment_through_store_credit.html.erb
@@ -1,4 +1,4 @@
-<% if @order.total_applicable_store_credit > 0 %>
+<% if @order.using_store_credit? %>
   <h6>Store credit will be applied for this order!</h6>
   <p><%= Spree::Money.new(@order.total_applicable_store_credit, { currency: @order.currency }).to_html %> in store credit will be applied to this order (<%= @order.display_store_credit_remaining_after_capture.to_html %> remaining)</p>
   <% if @order.covered_by_store_credit? %>

--- a/app/views/spree/checkout/_store_credits_sidebar.html.erb
+++ b/app/views/spree/checkout/_store_credits_sidebar.html.erb
@@ -1,4 +1,4 @@
-<% if order.total_applicable_store_credit > 0 %>
+<% if order.using_store_credit? %>
   <tr class="top-accent-separator">
     <td>Order Total:</td>
     <td><span id='summary-sub-total'><%= order.display_total.to_html %></span></td>

--- a/app/views/spree/checkout/_store_credits_sidebar.html.erb
+++ b/app/views/spree/checkout/_store_credits_sidebar.html.erb
@@ -1,0 +1,10 @@
+<% if order.total_applicable_store_credit > 0 %>
+  <tr class="top-accent-separator">
+    <td>Order Total:</td>
+    <td><span id='summary-sub-total'><%= order.display_total.to_html %></span></td>
+  </tr>
+  <tr class="bottom-accent-separator">
+    <td>Store Credit</td>
+    <td><strong><span id='summary-store-credit'><%= order.display_total_applicable_store_credit.to_html %></span></strong></td>
+  </tr>
+<% end %>

--- a/app/views/spree/shared/_order_details_store_credit.html.erb
+++ b/app/views/spree/shared/_order_details_store_credit.html.erb
@@ -1,0 +1,13 @@
+<tfoot class="top-accent-separator light" id="order-total-without-cred">
+  <tr class="total">
+    <td colspan="4"><strong>Order Total</strong></td>
+    <td class="total"><span><%= order.display_total.to_html %></span></td>
+  </tr>
+</tfoot>
+
+<tfoot id="order-store-credit">
+  <tr class="total">
+    <td colspan="4"><strong>Store Credit</strong></td>
+    <td class="total"><span><%= order.display_total_applicable_store_credit.to_html %></span></td>
+  </tr>
+</tfoot>

--- a/app/views/spree/shared/_order_details_store_credit.html.erb
+++ b/app/views/spree/shared/_order_details_store_credit.html.erb
@@ -1,13 +1,15 @@
-<tfoot class="top-accent-separator light" id="order-total-without-cred">
-  <tr class="total">
-    <td colspan="4"><strong>Order Total</strong></td>
-    <td class="total"><span><%= order.display_total.to_html %></span></td>
-  </tr>
-</tfoot>
+<% if order.using_store_credit? %>
+  <tfoot class="top-accent-separator light" id="order-total-without-cred">
+    <tr class="total">
+      <td colspan="4"><strong>Order Total</strong></td>
+      <td class="total"><span><%= order.display_total.to_html %></span></td>
+    </tr>
+  </tfoot>
 
-<tfoot id="order-store-credit">
-  <tr class="total">
-    <td colspan="4"><strong>Store Credit</strong></td>
-    <td class="total"><span><%= order.display_total_applicable_store_credit.to_html %></span></td>
-  </tr>
-</tfoot>
+  <tfoot id="order-store-credit">
+    <tr class="total">
+      <td colspan="4"><strong>Store Credit</strong></td>
+      <td class="total"><span><%= order.display_total_applicable_store_credit.to_html %></span></td>
+    </tr>
+  </tfoot>
+<% end %>

--- a/app/views/spree/shared/_order_details_total_charge.html.erb
+++ b/app/views/spree/shared/_order_details_total_charge.html.erb
@@ -1,0 +1,2 @@
+<td colspan="4"><b>Balance Due:</b></td>
+<td class="total"><span id="order_total"><%= @order.display_order_total_after_store_credit.to_html %></span></td>

--- a/spec/models/spree/order_decorator_spec.rb
+++ b/spec/models/spree/order_decorator_spec.rb
@@ -266,6 +266,58 @@ describe "Order" do
     end
   end
 
+  describe "#using_store_credit?" do
+    let(:order) { create(:order) }
+    subject { order.using_store_credit? } 
+
+    context "order is in the confirm state" do
+      before { order.update_attributes(state: 'confirm') }
+
+      context "when there is a store credit payment" do
+        let!(:store_credit_payment) { create(:store_credit_payment, order: order) } 
+        it { should be true }
+      end
+
+      context "when there is not store credit payment" do
+        it { should be false }
+      end
+    end
+
+    context "order is completed" do
+      before { order.update_attributes(state: 'complete') }
+
+      context "when there is a store credit payment" do
+        let!(:store_credit_payment) { create(:store_credit_payment, order: order) } 
+        it { should be true }
+      end
+
+      context "when there is not store credit payment" do
+        it { should be false }
+      end
+    end
+
+    context "order is in any state other than confirm or complete" do
+      context "the associated user has store credits" do
+        let(:store_credit) { create(:store_credit) }
+        let(:order)        { create(:order_with_line_items, user: store_credit.user) }
+
+        it { should be true }
+      end
+
+      context "the associated user does not have store credits" do
+        let(:order) { create(:order_with_line_items) }
+
+        it { should be false }
+      end
+
+      context "the order does not have an associated user" do
+        let(:order) { create(:store_credits_order_without_user) }
+
+        it { should be false }
+      end
+    end
+  end
+
   describe "#order_total_after_store_credit" do
     let(:order_total) { 100.0 }
 


### PR DESCRIPTION
Starts adding some UI for customers to see and deal with store credits. It is untested for the moment but maybe it can become the basis for some more frontend work if anyone is willing to pursue further!

Parts of the UI it attempts to cover:
- Shows store credit in side/summary bar
- Shows store credit when needing to enter in payment details, while
  making it clear that the customer will not be charged
- Shows store credit in the order confirmation page as well as the order
  show page
- A customer's order index page still shows the usual order total
  (unchanged behavior)
