### PR TITLE
Add store credits seeds.

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,0 +1,6 @@
+Spree::PaymentMethod.find_or_create_by(type: "Spree::PaymentMethod::StoreCredit", name: "Store Credit", description: "Store credit.", active: true, environment: Rails.env, display_on: 'back_end')
+
+Spree::StoreCreditType.find_or_create_by(name: 'Expiring', priority: 1)
+Spree::StoreCreditType.find_or_create_by(name: 'Non-expiring', priority: 2)
+
+Spree::StoreCreditCategory.find_or_create_by(name: 'Gift Card')

--- a/lib/generators/spree_store_credits/install/install_generator.rb
+++ b/lib/generators/spree_store_credits/install/install_generator.rb
@@ -14,6 +14,13 @@ module SpreeStoreCredits
         inject_into_file 'vendor/assets/stylesheets/spree/backend/all.css', " *= require spree/backend/spree_store_credits\n", :before => /\*\//, :verbose => true
       end
 
+      def include_seed_data
+        append_file "db/seeds.rb", <<-SEEDS
+\n
+SpreeStoreCredits::Engine.load_seed if defined?(SpreeStoreCredits::Engine)
+        SEEDS
+      end
+
       def add_migrations
         run 'bundle exec rake railties:install:migrations FROM=spree_store_credits'
       end


### PR DESCRIPTION
Without the seeds, things don't work correctly. If you run the
migrations this data will be added, but if a new developer/environment
is created from seeds then things don't work quite right.
