### PR TITLE
Stop using ActiveSupport::Concern

### DIFF
--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -1,10 +1,8 @@
 module Spree::LineItemDecorator
-  extend ActiveSupport::Concern
-
-  included do
-    has_many :gift_cards, class_name: Spree::VirtualGiftCard
-    delegate :gift_card?, :gift_card, to: :product
-    prepend(InstanceMethods)
+  def self.included(base)
+    base.has_many :gift_cards, class_name: Spree::VirtualGiftCard
+    base.delegate :gift_card?, :gift_card, to: :product
+    base.prepend(InstanceMethods)
   end
 
   module InstanceMethods

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -1,11 +1,9 @@
 module SpreeStoreCredits::OrderDecorator
-  extend ActiveSupport::Concern
+  def self.included(base)
+    base.state_machine.before_transition to: :confirm, do: :add_store_credit_payments
+    base.state_machine.after_transition to: :confirm, do: :create_gift_cards
 
-  included do
-    Spree::Order.state_machine.before_transition to: :confirm, do: :add_store_credit_payments
-    Spree::Order.state_machine.after_transition to: :confirm, do: :create_gift_cards
-
-    prepend(InstanceMethods)
+    base.prepend(InstanceMethods)
   end
 
   module InstanceMethods

--- a/app/models/spree/payment_decorator.rb
+++ b/app/models/spree/payment_decorator.rb
@@ -1,12 +1,10 @@
 module SpreeStoreCredits::PaymentDecorator
-  extend ActiveSupport::Concern
-
-  included do
-    delegate :store_credit?, to: :payment_method
-    scope :store_credits, -> { where(source_type: Spree::StoreCredit.to_s) }
-    scope :not_store_credits, -> { where(arel_table[:source_type].not_eq(Spree::StoreCredit.to_s).or(arel_table[:source_type].eq(nil))) }
-    after_create :create_eligible_credit_event
-    prepend(InstanceMethods)
+  def self.included(base)
+    base.delegate :store_credit?, to: :payment_method
+    base.scope :store_credits, -> { base.where(source_type: Spree::StoreCredit.to_s) }
+    base.scope :not_store_credits, -> { base.where(base.arel_table[:source_type].not_eq(Spree::StoreCredit.to_s).or(base.arel_table[:source_type].eq(nil))) }
+    base.after_create :create_eligible_credit_event
+    base.prepend(InstanceMethods)
   end
 
   module InstanceMethods

--- a/app/models/spree/payment_method_decorator.rb
+++ b/app/models/spree/payment_method_decorator.rb
@@ -1,8 +1,7 @@
 module SpreeStoreCredits::PaymentMethodDecorator
-  extend ActiveSupport::Concern
 
-  included do
-    prepend(InstanceMethods)
+  def self.included(base)
+    base.prepend(InstanceMethods)
   end
 
   module InstanceMethods

--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -1,11 +1,9 @@
 module Spree::UserDecorator
-  extend ActiveSupport::Concern
+  def self.included(base)
+    base.has_many :store_credits, -> { includes(:credit_type) }
+    base.has_many :store_credit_events, through: :store_credits
 
-  included do
-    has_many :store_credits, -> { includes(:credit_type) }
-    has_many :store_credit_events, through: :store_credits
-
-    prepend(InstanceMethods)
+    base.prepend(InstanceMethods)
   end
 
   module InstanceMethods


### PR DESCRIPTION
ActiveSupport::Concern does not deal with some changes to Rails 4.1
autoloading, leading to issues with multiple included blocks being defined
when modifying files in the Rails development environment.

Not defining included as a block seems to allieviate this issue, so this 
commit strips the use of ActiveSupport::Concern, and just deals with
.include and .prepend directly.
