### PR TITLE
Default Spree::User from spree_auth_devise does not have first_name and last_name

### DIFF
--- a/app/views/spree/admin/gift_cards/show.html.erb
+++ b/app/views/spree/admin/gift_cards/show.html.erb
@@ -17,10 +17,10 @@
       <tr>
         <td class="align-center"><%= gift_card.formatted_redemption_code %></td>
         <td class="align-center"><%= number_to_currency(gift_card.amount) %></td>
-        <td class="align-center"><%= link_to "#{gift_card.purchaser.first_name} #{gift_card.purchaser.last_name}", edit_admin_user_path(gift_card.purchaser) %></td>
+        <td class="align-center"><%= link_to gift_card.purchaser.email, edit_admin_user_path(gift_card.purchaser) %></td>
         <td class="align-center"><%= gift_card.created_at.localtime.strftime("%F %I:%M%p") %></td>
         <% if gift_card.redeemed? %>
-          <td class="align-center"><%= link_to "#{gift_card.redeemer.first_name} #{gift_card.redeemer.last_name}", edit_admin_user_path(gift_card.redeemer) %></td>
+          <td class="align-center"><%= link_to gift_card.redeemer.email, edit_admin_user_path(gift_card.redeemer) %></td>
           <td class="align-center"><%= gift_card.redeemed_at.localtime.strftime("%F %I:%M%p") %></td>
         <% else %>
           <td class="align-center"></td>


### PR DESCRIPTION
The spree_auth_devise extension just uses `email` for its user display, should probably do the same in here.  See create table here: https://github.com/spree/spree_auth_devise/blob/master/db/migrate/20101026184949_create_users.rb or use of email display here: https://github.com/spree/spree_auth_devise/blob/master/lib/views/backend/spree/layouts/admin/_login_nav.html.erb#L3
