### PR TITLE
Fix issues caused by float imprecision

### DIFF
--- a/app/models/spree/payment_method/store_credit.rb
+++ b/app/models/spree/payment_method/store_credit.rb
@@ -19,7 +19,7 @@ module Spree
       else
         action = -> (store_credit) {
           store_credit.authorize(
-            amount_in_cents / 100.0,
+            amount_in_cents / 100.0.to_d,
             gateway_options[:currency],
             action_originator: gateway_options[:originator]
           )
@@ -31,7 +31,7 @@ module Spree
     def capture(amount_in_cents, auth_code, gateway_options = {})
       action = -> (store_credit) {
         store_credit.capture(
-          amount_in_cents / 100.0,
+          amount_in_cents / 100.0.to_d,
           auth_code,
           gateway_options[:currency],
           action_originator: gateway_options[:originator]
@@ -42,7 +42,7 @@ module Spree
     end
 
     def purchase(amount_in_cents, store_credit, gateway_options = {})
-      eligible_events = store_credit.store_credit_events.where(amount: amount_in_cents / 100.0, action: Spree::StoreCredit::ELIGIBLE_ACTION)
+      eligible_events = store_credit.store_credit_events.where(amount: amount_in_cents / 100.0.to_d, action: Spree::StoreCredit::ELIGIBLE_ACTION)
       event = eligible_events.find do |eligible_event|
         store_credit.store_credit_events.where(authorization_code: eligible_event.authorization_code)
                                         .where.not(action: Spree::StoreCredit::ELIGIBLE_ACTION).empty?
@@ -67,7 +67,7 @@ module Spree
         currency = gateway_options[:currency] || store_credit.currency
         originator = gateway_options[:originator]
 
-        store_credit.credit(amount_in_cents / 100.0, auth_code, currency, action_originator: originator)
+        store_credit.credit(amount_in_cents / 100.0.to_d, auth_code, currency, action_originator: originator)
       end
 
       handle_action(action, :credit, auth_code)

--- a/app/models/spree/store_credit.rb
+++ b/app/models/spree/store_credit.rb
@@ -70,7 +70,7 @@ class Spree::StoreCredit < ActiveRecord::Base
   end
 
   def validate_authorization(amount, order_currency)
-    if amount_remaining < amount
+    if amount_remaining.to_d < amount.to_d
       errors.add(:base, Spree.t('store_credit_payment_method.insufficient_funds'))
     elsif currency != order_currency
       errors.add(:base, Spree.t('store_credit_payment_method.currency_mismatch'))

--- a/spec/models/spree/store_credit_spec.rb
+++ b/spec/models/spree/store_credit_spec.rb
@@ -3,7 +3,8 @@ require 'spec_helper'
 describe "StoreCredit" do
 
   let(:currency) { "TEST" }
-  let(:store_credit) { build(:store_credit) }
+  let(:store_credit) { build(:store_credit, store_credit_attrs) }
+  let(:store_credit_attrs) { {} }
 
 
   describe "callbacks" do
@@ -240,6 +241,15 @@ describe "StoreCredit" do
       it "returns true" do
         expect(subject).to be true
       end
+    end
+
+    context 'troublesome floats' do
+      # 8.21.to_d < 8.21 => true
+      let(:store_credit_attrs) { {amount: 8.21} }
+
+      subject { store_credit.validate_authorization(store_credit_attrs[:amount], store_credit.currency) }
+
+      it { should be_truthy }
     end
   end
 


### PR DESCRIPTION
Because, e.g., `8.21.to_d != 8.21`

This was causing `validate_authorization` to fail for certain numbers because it didn't think enough funds were available.
