### PR TITLE
Don't create gift cards until the order has been completed

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -1,12 +1,16 @@
 module SpreeStoreCredits::OrderDecorator
   def self.included(base)
     base.state_machine.before_transition to: :confirm, do: :add_store_credit_payments
-    base.state_machine.after_transition to: :confirm, do: :create_gift_cards
 
     base.prepend(InstanceMethods)
   end
 
   module InstanceMethods
+    def finalize!
+      create_gift_cards
+      super
+    end
+
     def create_gift_cards
       line_items.each do |item|
         item.quantity.times do

--- a/spec/models/spree/order_decorator_spec.rb
+++ b/spec/models/spree/order_decorator_spec.rb
@@ -292,6 +292,19 @@ describe "Order" do
     end
   end
 
+  describe "#finalize!" do
+    context "the order contains gift cards and transitions to complete" do
+      let(:order) { create(:order_with_line_items, state: 'complete') }
+
+      subject { order.finalize! }
+
+      it "calls #create_gift_cards" do
+        order.should_receive(:create_gift_cards)
+        subject
+      end
+    end
+  end
+
   describe "#total_applicable_store_credit" do
     context "order is in the confirm state" do
       before { order.update_attributes(state: 'confirm') }

--- a/spree_store_credits.gemspec
+++ b/spree_store_credits.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree', '2.4.0.beta'
+  s.add_dependency 'spree', '2.4.0.rc3'
 
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'coffee-rails'


### PR DESCRIPTION
Gift cards are being created after an order transitions to the confirm state, which causes issues if the order bounces back to an earlier state and the line item for the gift card is modified.

For instance, if a user adds 2 gift cards to their cart, reaches the confirm state, then goes back and removes one of the gift cards, they'll still have 2 valid gift cards associated with the line item.

`finalize!` seems like a much better place for this, as we can be assured that the order has been completed.

I also bumped spree in the gemspec. I had issues bundling and it looks like the master branch of Spree is now up to rc3, which fixed the issue.
