### PR TITLE
Handle odd length redemption codes in formatting

### DIFF
--- a/app/models/spree/virtual_gift_card.rb
+++ b/app/models/spree/virtual_gift_card.rb
@@ -38,7 +38,7 @@ class Spree::VirtualGiftCard < ActiveRecord::Base
   end
 
   def formatted_redemption_code
-    redemption_code.scan(/.{4}/).join('-')
+    redemption_code.scan(/.{1,4}/).join('-')
   end
 
   def formatted_amount

--- a/spec/models/spree/virtual_gift_card_spec.rb
+++ b/spec/models/spree/virtual_gift_card_spec.rb
@@ -165,8 +165,8 @@ describe "VirtualGiftCard" do
   end
 
   describe '#formatted_redemption_code' do
-    let(:redemption_code) { 'AAAABBBBCCCCDDDD' }
-    let(:formatted_redemption_code) { 'AAAA-BBBB-CCCC-DDDD' }
+    let(:redemption_code) { 'AAAABBBBCCCCDD' }
+    let(:formatted_redemption_code) { 'AAAA-BBBB-CCCC-DD' }
     let(:gift_card) { Spree::VirtualGiftCard.create(amount: 20, currency: 'USD') }
 
     subject { gift_card.formatted_redemption_code }


### PR DESCRIPTION
We have some legacy codes and codes generated via other methods, and their lengths are not divisible by 4, so it results in truncated formatted codes in the UI.
